### PR TITLE
fix: Improved error logging on bind

### DIFF
--- a/files/aldap.py
+++ b/files/aldap.py
@@ -51,7 +51,7 @@ class Aldap:
 		except ldap.INVALID_CREDENTIALS:
 			self.logs.warning({'message':'Invalid credentials.', 'username': self.username})
 		except ldap.LDAPError as e:
-			self.logs.error({'message':'There was an error trying to bind.'})
+			self.logs.error({'message':'There was an error trying to bind: %s' % e})
 
 		return False
 
@@ -65,8 +65,7 @@ class Aldap:
 			end = time.time()-start
 			self.logs.info({'message':'Search by filter.', 'filter': self.searchFilter, 'elapsedTime': str(end)})
 		except ldap.LDAPError as e:
-			self.logs.error({'message':'There was an error trying to bind meanwhile trying to do a search.'})
-			print(e)
+			self.logs.error({'message':'There was an error trying to bind meanwhile trying to do a search: %s' % e})
 
 		return result
 


### PR DESCRIPTION
Currently no specific error message is logged when the bind fails - making it difficult to track down errors. In this pull request the specific error message gets appended to the logged info message.