### PR TITLE
Allow setting ldap passwd secret through values

### DIFF
--- a/chart/another-ldap-auth/templates/secret.yaml
+++ b/chart/another-ldap-auth/templates/secret.yaml
@@ -5,5 +5,5 @@ metadata:
   name: {{ include "another-ldap-auth.fullname" . }}
 type: Opaque
 data:
-  LDAP_MANAGER_PASSWORD: <your-password-in-base64>
+  LDAP_MANAGER_PASSWORD: {{ .Values.ldap.managerDnPassword | b64enc }}
 {{- end }}

--- a/chart/another-ldap-auth/values.yaml
+++ b/chart/another-ldap-auth/values.yaml
@@ -17,6 +17,7 @@ ldap:
   httpsSupport: "enabled"
   endpoint: "ldaps://testmyldap.com:636"
   managerDnUsername: "CN=john,OU=Administrators,DC=TESTMYLDAP,DC=COM"
+  managerDnPassword:
   serverDomain: "TESTMYLDAP.COM"
   searchBase: "DC=TESTMYLDAP,DC=COM"
   searchFilter: "(sAMAccountName={username})"


### PR DESCRIPTION
This PR adds the option to set up the password in secret through values. As there was no other way than changing the template itself. User still can use e.g. helm secrets (sops) or other systems to securely handle secret management.