### PR TITLE
[#41] Publish chart to gh-pages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,27 @@
+name: another-ldap-auth chart
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.2.1
+        with:
+          charts_dir: chart
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Does not seem to work - I think it's related to tags. 
I don't use tags in my build and it works: https://github.com/ieugen/charts/runs/4694689950?check_suite_focus=true  . 

Fixes https://github.com/dignajar/another-ldap-auth/issues/41 